### PR TITLE
fix: APIのタイムゾーン情報を無視してJSTとして扱うように修正

### DIFF
--- a/batch/src/index.ts
+++ b/batch/src/index.ts
@@ -114,8 +114,10 @@ async function scrapeEventFinder(): Promise<FaBEvent[]> {
 							continue; // 50kmより遠いイベントはスキップ
 						}
 
-						// イベントの日時をパース (ISO 8601形式)
-						const startDatetime = new Date(event.start_time);
+						// イベントの日時をパース
+						// APIのタイムゾーン情報が不正確なため、タイムゾーンを除去してJSTとして扱う
+						const timeWithoutTz = event.start_time.replace(/[+-]\d{2}:\d{2}$/, '');
+						const startDatetime = new Date(timeWithoutTz + '+09:00');
 
 						// イベント名と場所を取得
 						const eventName = event.nickname || '';


### PR DESCRIPTION
## Summary
- APIから返されるイベント日時のタイムゾーン情報が不正確な問題を修正
- タイムゾーン部分を除去してから日本時間（JST/UTC+9）として扱うように変更

## 問題
APIは`2025-10-04T14:00:00+13:00`のような形式で日時を返しますが、このタイムゾーン情報（`+13:00`）は実際の日本時間と異なります。このため、14:00のイベントが10:00（または深夜1:00）として表示される問題が発生していました。

例: 「プロクエスト：横浜@TOKYO FAB」が本来14:00開始なのに、1:00として表示される

## 解決策
タイムゾーン部分（`+13:00`等）を除去してから、日本時間（`+09:00`）を付加することで、正しい時刻として扱うように修正しました。

```typescript
const timeWithoutTz = event.start_time.replace(/[+-]\d{2}:\d{2}$/, '');
const startDatetime = new Date(timeWithoutTz + '+09:00');
```

## Test plan
- [ ] ローカル環境での動作確認（`yarn dev`）
- [ ] カレンダーファイルの日時が正しく表示されることを確認
- [ ] 「プロクエスト：横浜@TOKYO FAB」が14:00開始として表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)