### PR TITLE
fix: 繰り返しイベント展開の最適化で外部カレンダー取り込みを安定化

### DIFF
--- a/batch/src/index.test.ts
+++ b/batch/src/index.test.ts
@@ -120,6 +120,57 @@ test('同一店舗・同一フォーマット・30分以内の公式イベント
 	assert.equal(merged[0]?.title, externalEvents[0]?.title);
 });
 
+test('RRULE UNTILが過去日付の繰り返しイベントはスキップされる', () => {
+	const now = new Date('2026-03-22T00:00:00Z');
+	const icalText = buildIcs([
+		buildEvent({
+			uid: 'past-until-1',
+			dtstart: '20230101T100000Z',
+			summary: 'Old Weekly Blitz',
+			location: 'Tokyo FAB',
+			rrule: 'FREQ=WEEKLY;UNTIL=20250101T000000Z',
+		}),
+	]);
+
+	const events = parseICalEvents(icalText, TOKYO_FAB_SOURCE, LOCAL_ENV, now);
+
+	assert.equal(events.length, 0);
+});
+
+test('RRULE UNTILが未来日付の繰り返しイベントはスキップされない', () => {
+	const now = new Date('2026-03-22T00:00:00Z');
+	const icalText = buildIcs([
+		buildEvent({
+			uid: 'future-until-1',
+			dtstart: '20260322T100000Z',
+			summary: 'Active Weekly CC',
+			location: 'Tokyo FAB',
+			rrule: 'FREQ=WEEKLY;UNTIL=20260501T000000Z',
+		}),
+	]);
+
+	const events = parseICalEvents(icalText, TOKYO_FAB_SOURCE, LOCAL_ENV, now);
+
+	assert.ok(events.length > 0, `期待: 1件以上のイベント、実際: ${events.length}件`);
+});
+
+test('RRULE UNTILなし（無期限）の繰り返しイベントはスキップされない', () => {
+	const now = new Date('2026-03-22T00:00:00Z');
+	const icalText = buildIcs([
+		buildEvent({
+			uid: 'no-until-1',
+			dtstart: '20260322T100000Z',
+			summary: 'Ongoing Weekly Blitz',
+			location: 'Tokyo FAB',
+			rrule: 'FREQ=WEEKLY;COUNT=10',
+		}),
+	]);
+
+	const events = parseICalEvents(icalText, TOKYO_FAB_SOURCE, LOCAL_ENV, now);
+
+	assert.ok(events.length > 0, `期待: 1件以上のイベント、実際: ${events.length}件`);
+});
+
 test('店舗またはフォーマットが違う公式イベントは重複扱いしない', () => {
 	const now = new Date('2026-03-22T00:00:00Z');
 	const externalEvents = [

--- a/batch/src/index.ts
+++ b/batch/src/index.ts
@@ -22,7 +22,8 @@ const EXTERNAL_LOOKAHEAD_DAYS = 30;
 const ICAL_CACHE_TTL_SECONDS = 6 * 60 * 60; // 6時間
 const DUPLICATE_TIME_THRESHOLD_MS = 30 * MILLISECONDS_PER_MINUTE;
 const DUPLICATE_TIME_BUCKET_MS = DUPLICATE_TIME_THRESHOLD_MS;
-const RECURRENCE_EXPANSION_LIMIT = 50;
+// 過去に開始した繰り返しイベント（例: 2023年10月開始の週次イベント）が現在日まで到達するために必要な余裕（週次で約7年分）
+const RECURRENCE_EXPANSION_LIMIT = 365;
 const EXCLUDED_EXTERNAL_KEYWORDS = ['grand archive', '定休日'];
 const NON_GAME_KEYWORDS = ['定休日', '休み', '休業', 'closed'];
 const COMMON_DUPLICATE_KEYWORDS = ['learn to play', 'armory', 'blitz', 'classic constructed', 'pro quest', 'draft', 'on demand', 'cc', 'll', 'pb'];
@@ -309,6 +310,18 @@ function parseICalEvents(icalText: string, source: string, env?: Env, now = new 
 				
 				// Handle recurring events by expanding them
 				if (event.isRecurring()) {
+					// 終了済み繰り返しイベントをスキップ（CPU時間の節約）
+					const rruleProp = vevent.getFirstProperty('rrule');
+					if (rruleProp) {
+						const rruleVal = rruleProp.getFirstValue();
+						if (rruleVal && rruleVal.until) {
+							const untilDate = rruleVal.until.toJSDate();
+							if (untilDate < now) {
+								continue;
+							}
+						}
+					}
+
 					try {
 						const recurExpander = new ICAL.RecurExpansion({
 							component: event.component,


### PR DESCRIPTION
## Summary

- 終了済みRRULEイベント（UNTIL < now）を展開前にスキップし、CPU時間を大幅に削減
- `RECURRENCE_EXPANSION_LIMIT` を50→365に引き上げ、2023年開始の週次イベントが現在日まで到達可能に
- UNTILスキップロジックのユニットテスト3件を追加

## 背景

Tokyo FABのGoogle Calendarに364件の繰り返しイベントがあり、その大半が終了済み（UNTILが過去）。これらを全て展開しようとしてCPU時間超過（exceededResources）が発生し、外部カレンダーの取り込みが不安定になっていた。また、RECURRENCE_EXPANSION_LIMIT=50では2023年開始の週次イベントが現在日（約130週先）まで到達できず、イベントの取りこぼしも発生していた。

## Test plan

- [x] ローカルテスト（`yarn tsx src/local.ts`）で正常にイベント取得を確認
- [x] ユニットテスト全7件合格（既存4 + 新規3）
- [ ] CI通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)